### PR TITLE
Censor profane words

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,1 +1,1 @@
-print "cirpo", "culo"
+print "cirpo", "c***"


### PR DESCRIPTION
Especially when they are mentioned next to "cirpo". @cirpo should never appear next to a [negative word](https://en.wikipedia.org/wiki/Four-letter_word).
